### PR TITLE
Fix compile errors

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -85,7 +85,7 @@ type API =
         -- | List Article
       :<|> "api" :> "articles"
            :> QueryParam "limit" Limit :> QueryParam "offset" Offset
-           :> QueryParam "author" Author :> QueryParam "tag" Tagged
+           :> QueryParam "author" Author :> QueryParam "tag" Types.Tagged
            :> QueryParam "favourited" FavoritedBy
            :> AuthProtect "JWT-optional"
            :> Get '[JSON] (Arts [Article])
@@ -307,7 +307,7 @@ listArticlesHandler :: Connection
                     -> Maybe Limit
                     -> Maybe Offset
                     -> Maybe Author
-                    -> Maybe Tagged
+                    -> Maybe Types.Tagged
                     -> Maybe FavoritedBy
                     -> Maybe DBUser
                     -> Handler (Arts [Article])

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.12
+resolver: lts-11.6
 
 packages:
 - '.'


### PR DESCRIPTION
I checked out this project and bumped into these compile errors:

```shell
Building executable 'haskell-servant-realworld-example-app' for haskell-servant-realworld-example-app-0.0.1.0..
[1 of 3] Compiling Types            ( src/Types.hs, .stack-work/dist/x86_64-osx/Cabal-2.0.1.0/build/haskell-servant-realworld-example-app/haskell-servant-realworld-example-app-tmp/Types.o )
[2 of 3] Compiling DB               ( src/DB.hs, .stack-work/dist/x86_64-osx/Cabal-2.0.1.0/build/haskell-servant-realworld-example-app/haskell-servant-realworld-example-app-tmp/DB.o )
[3 of 3] Compiling Main             ( src/Main.hs, .stack-work/dist/x86_64-osx/Cabal-2.0.1.0/build/haskell-servant-realworld-example-app/haskell-servant-realworld-example-app-tmp/Main.o )

/tmp/haskell-servant-realworld-example-app/src/Main.hs:88:62: error:
    Ambiguous occurrence ‘Tagged’
    It could refer to either ‘Servant.Tagged’,
                             imported from ‘Servant’ at src/Main.hs:24:1-24
                             (and originally defined in ‘tagged-0.8.5:Data.Tagged’)
                          or ‘Types.Tagged’,
                             imported from ‘Types’ at src/Main.hs:27:1-22
                             (and originally defined at src/Types.hs:43:1-18)
   |
88 |            :> QueryParam "author" Author :> QueryParam "tag" Tagged
   |                                                              ^^^^^^

/tmp/haskell-servant-realworld-example-app/src/Main.hs:310:30: error:
    Ambiguous occurrence ‘Tagged’
    It could refer to either ‘Servant.Tagged’,
                             imported from ‘Servant’ at src/Main.hs:24:1-24
                             (and originally defined in ‘tagged-0.8.5:Data.Tagged’)
                          or ‘Types.Tagged’,
                             imported from ‘Types’ at src/Main.hs:27:1-22
                             (and originally defined at src/Types.hs:43:1-18)
    |
310 |                     -> Maybe Tagged
    |                              ^^^^^^

Completed 49 action(s).

--  While building custom Setup.hs for package haskell-servant-realworld-example-app-0.0.1.0 using:
      /tmp/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_2.0.1.0_ghc-8.2.2 --builddir=.stack-work/dist/x86_64-osx/Cabal-2.0.1.0 build exe:haskell-servant-realworld-example-app --ghc-options " -ddump-hi -ddump-to-file -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
```

I also bumped the resolver, hope that's OK 🤞.