### PR TITLE
Turn on Servant logging - we should see what's going on

### DIFF
--- a/haskell-servant-realworld-example-app.cabal
+++ b/haskell-servant-realworld-example-app.cabal
@@ -17,6 +17,7 @@ executable haskell-servant-realworld-example-app
   hs-source-dirs:      src
   main-is:             Main.hs
   default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base >= 4.7 && < 5
                      , time
                      , text
@@ -24,6 +25,7 @@ executable haskell-servant-realworld-example-app
                      , servant-server
                      , mtl
                      , wai
+                     , wai-logger
                      , warp
                      , aeson
                      , sqlite-simple


### PR DESCRIPTION
As I tried to hit the endpoints, I did not see if Servant recognized the request or not. I figured, running the logs should be on by default, that would help people to use the app.

Before this change, this is what I had in the console:

```shell
stack exec haskell-servant-realworld-example-app logger
"Let's go!"
```

After the change:

```shell
stack exec haskell-servant-realworld-example-app logger
"Let's go!"
127.0.0.1 - - [14/May/2018:22:25:55 -0500] "GET / HTTP/1.1" 404 - "" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36"
```